### PR TITLE
Add `pushState` compliant option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ contents of `./public` served over HTTP.
 
 ```bash
 // Start server at http://localhost:3000 serving ./public
-$ static --port 3000
+$ statik --port 3000
 
 // Start server at http://localhost:3000 serving ~/Sites/project
 $ statik --port 3000 ~/Sites/project
@@ -31,6 +31,7 @@ $ statik --port 3000 ~/Sites/project
 * **redirect**: redirect to trailing "/" when pathname is directory. Defaults to true
 * **compress**: enable gzip compression. Defaults to true
 * **verbose**: enable logging to stdout. Defaults to false
+* **pushstate**: enable pushState compliant fallback to index.html. Defaults to false
 
 ## Use it programmatically
 
@@ -58,7 +59,8 @@ You can specify the directory you wish to serve as an argument.
 var statik = require('statik');
 statik({
 	port: 3000,
-	root: '/Users/hongymagic/Sites'
+	root: '/Users/hongymagic/Sites',
+	pushstate: true
 });
 ```
 
@@ -103,6 +105,10 @@ will be an option to disable to default behaviour though.
 
 > For now, it will translate that into `index.html`
 
+### What does the `pushstate` option does exactly?
+
+If the request url does not match an existing file, the `:root:/index.html` file will be served instead. This allows you to serve single page application that use the [`pushState API`](https://developer.mozilla.org/en-US/docs/Web/API/History_API).
+
 ## TODO
 
 1. Clean up code around 404 and 500 errors
@@ -111,4 +117,3 @@ will be an option to disable to default behaviour though.
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/hongymagic/statik/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/bin/statik
+++ b/bin/statik
@@ -14,24 +14,34 @@ var usage = [
 '  --hidden      Allow hidden files to be served. Defaults to false.',
 '  --redirect    Redirect to trailing "/" when pathname is directory. Defaults to true.',
 '  --maxAge      Browser cache maxAge in milliseconds. Defaults to 0.',
-'  --verbose     Enable verbose logging to stdout. Defaults to false.'
+'  --verbose     Enable verbose logging to stdout. Defaults to false.',
+'  --pushstate   Enable fallback to index.html when requested URL does not exist.',
+'  --sslCert     Provde ssl cert for https server. Arg is path to cert minus the file extension'
 ].join('\n');
 
 var nopt = require('nopt');
 var path = require('path');
 var known = {
 	"port": Number,
-	"maxAge": Boolean,
+	"maxAge": Number,
 	"hidden": Boolean,
 	"redirect": Boolean,
 	"compress": Boolean,
 	"verbose": Boolean,
-	"help": Boolean
+	"help": Boolean,
+	"pushstate": Boolean,
+	"sslCert": String
 };
-var options = nopt(known);
+var shorthands = {
+	"p": ["--port"],
+	"a": ["--maxAge"],
+	"c": ["--compress"],
+	"s": ["--pushstate"]
+};
+var options = nopt(known, shorthands);
 
 if (options.help)
-	return console.log(usage);
+    return console.log(usage);
 
 if (options.argv.remain[0] !== undefined)
 	options.root = path.resolve(options.argv.remain[0]);

--- a/examples/basic-port.js
+++ b/examples/basic-port.js
@@ -2,11 +2,11 @@
 // ## Barebones demonstration.
 //
 // The following code will serve everything inside `./public` over HTTP using
-// port 3000.
+// port 3033.
 //
 
 var statik = require('../index');
-var server = statik.createServer();
+var server = statik();
 
-server.listen(3000);
-console.log("server online at http://localhost:3000/");
+server.listen(3033);
+console.log("server online at http://localhost:3033/");

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -6,7 +6,7 @@
 //
 
 var statik = require('../index');
-var server = statik.createServer();
+var server = statik();
 
 server.listen();
 console.log("server online at http://localhost:1203/");

--- a/examples/public/index.html
+++ b/examples/public/index.html
@@ -4,9 +4,9 @@
 		<title>It works!</title>
 	</head>
 	<body>
-		<p>Of course it works!</p>
+		<p>Of course it works (from root)!</p>
 
-		<script src="scripts/jquery-1.10.2.js"></script>
-		<script src="scripts/app.js"></script>
+		<script src="/scripts/jquery-1.10.2.js"></script>
+		<script src="/scripts/app.js"></script>
 	</body>
 </html>

--- a/examples/public/views/index.html
+++ b/examples/public/views/index.html
@@ -4,8 +4,8 @@
 		<title>This is a sub folder</title>
 	</head>
 	<body>
-		<p>Of course it works!</p>
+		<p>Of course it works (from subfolder)!</p>
 
-		<script src="../scripts/app.js"></script>
+		<script src="/scripts/app.js"></script>
 	</body>
 </html>

--- a/lib/statik.js
+++ b/lib/statik.js
@@ -1,39 +1,58 @@
+var https = require('https');
+var fs = require('fs');
 var path = require('path');
 var extend = require('extend');
 var connect = require('connect');
+var pushState = require('connect-pushstate');
+
 var defaults = {
-	/* connect options */
-	port: 3000,
+    /* connect options */
+    port: 3000,
 
-	/* connect.static options */
-	root: path.join(process.cwd(), 'public'),
-	maxAge: 0,
-	hidden: false,
-	redirect: true,
-
-	/* other options */
-	compress: true,
-	verbose: false
+    /* connect.static options */
+    root: path.join(process.cwd(), 'public'),
+    maxAge: 0,
+    hidden: false,
+    redirect: true,
+    sslCert: false,
+    /* other options */
+    compress: true,
+    verbose: false,
+    pushstate: false
 };
 
 module.exports = function (opts) {
-	var options = extend(Object.create(null), defaults, opts);
-	var app = connect();
+    var options = extend(Object.create(null), defaults, opts);
+    var app = connect();
+    var serverOpts = {};
 
-	// setup middlewares
-	if (options.compress) {
-		app.use(connect.compress());
-	}
+    // setup middlewares
+    if (options.compress) {
+        app.use(connect.compress());
+    }
 
-	if (options.verbose) {
-		app.use(connect.logger('short'));
-	}
+    if (options.verbose) {
+        app.use(connect.logger('short'));
+    }
 
-	app.use(connect.static(options.root, options));
+    if (options.pushstate) {
+        app.use(pushState());
+    }
 
-	// start the app on given port. defaults to 3000
-	app.listen(options.port);
+    app.use(connect.static(options.root, options));
 
-	return app;
+    if (options.sslCert) {
+        var path = options.sslCert;
+        if (!fs.statSync(path + '.crt')) throw new Error('Could not find file: ' + path + '.crt');
+        if (!fs.statSync(path + '.key')) throw new Error('Could not find file: ' + path + '.key');
+        https.createServer({
+            protocol: 'https',
+            key: fs.readFileSync(path + '.key').toString(),
+            cert: fs.readFileSync(path + '.crt').toString()
+        }, app).listen(options.port);
+    } else {
+        app.listen(options.port);
+    }
+
+    return app;
 };
-

--- a/package.json
+++ b/package.json
@@ -18,17 +18,14 @@
     "url": "https://github.com/hongymagic/statik/issues"
   },
   "dependencies": {
+    "connect": "~2.11.0",
+    "connect-pushstate": "^1.0.0",
     "extend": "~1.2.1",
-    "nopt": "~2.1.2",
-    "connect": "~2.11.0"
+    "nopt": "~2.1.2"
   },
   "devDependencies": {},
   "main": "index",
   "bin": "./bin/statik",
-  "engines": {
-    "node": "0.x.x",
-    "npm": "1.x.x"
-  },
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
The `pushState` option make it easy to use `statik` to serve single page application in dev mode.

Serving single page apps usually manipulate the browser history and allow the user to be on urls such as `foobar.com/items/12/details`. When trying to directly load this url, your browser will try to fetch the complete URL while what it _should_ do is actually get `foobar.com/index.html`.

This is exactly what this option does: if a request URL doesn't lead to an existing file, load `index.html` instead.

The implementation simply relies on a existing `connect-pushstate` middleware that does everything for us ; we just use it or not depending on config.

This PR also contains a very few fixes in example and documentation for the new feature.
